### PR TITLE
Update outofmemory.java

### DIFF
--- a/outofmemory.java
+++ b/outofmemory.java
@@ -1,19 +1,19 @@
-class outofmemory {
+class OutOfMemory {
  public static void main(String args[])throws Exception{
-    for (int i = 0 ; i < 100 ;i++) {
-Thread thread = new Thread (new MyOperation());
-thread.start();
+  for (int i = 0 ; i < 100 ;i++) {
+   Thread thread = new Thread (new MyOperation());
+   thread.start();
 
-while(thread.isAlive()){
-thread.sleep(500);
+   while(thread.isAlive()){
+    thread.sleep(500);
    }
   }
  }
 }
 
 class MyOperation extends Thread{
-protected double[] huge_buffer = null;
-public void run(){
-huge_buffer = new double[100000];
+ protected double[] huge_buffer = null;
+ public void run(){
+  huge_buffer = new double[100000];
  }
 }


### PR DESCRIPTION
動きました。
jpsでプロセスID確認し、jmap -hist [id]で、ヒープの使用状況を確認することができました。
[D = double[]がメモリの大部分を占めていますね。

Javaでは、クラス名の先頭を大文字にすることが慣習だそうです。修正しておきました。
また、単語区切りを大文字にすることにより示しています。これをキャメルケースと呼びます。
キャメル＝らくだですが、でこぼこしている様が、ふたこぶらくだのように見えるからだそうです。
